### PR TITLE
Update vcpkg pointer

### DIFF
--- a/gyromouse/Cargo.toml
+++ b/gyromouse/Cargo.toml
@@ -30,7 +30,7 @@ default-features = false
 [package.metadata.vcpkg]
 dependencies = ["sdl2"]
 git = "https://github.com/microsoft/vcpkg"
-rev = "a267ab118c09f56f3dae96c9a4b3410820ad2f0b"
+rev = "261c458af6e3eed5d099144aff95d2b5035f656b"
 
 [package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }


### PR DESCRIPTION
This unblocks windows-latest builds that seem to have broken on github
workflows at the previous commit.  Commit selected is current top of
tree.

Discussed in https://github.com/mcgoo/cargo-vcpkg/issues/9