### PR TITLE
Add license to Cargo.toml files

### DIFF
--- a/crates/dualshock-sys/Cargo.toml
+++ b/crates/dualshock-sys/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dualshock-sys"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/crates/dualshock/Cargo.toml
+++ b/crates/dualshock/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "dualshock"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/crates/hid-gamepad-sys/Cargo.toml
+++ b/crates/hid-gamepad-sys/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "hid-gamepad-sys"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/crates/hid-gamepad-types/Cargo.toml
+++ b/crates/hid-gamepad-types/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "hid-gamepad-types"
+license = "MIT"
 version = "0.1.0"
 edition = "2018"
 

--- a/crates/hid-gamepad/Cargo.toml
+++ b/crates/hid-gamepad/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "hid-gamepad"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/crates/joycon-sys/Cargo.toml
+++ b/crates/joycon-sys/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "joycon-sys"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/crates/joycon/Cargo.toml
+++ b/crates/joycon/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "joycon"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"

--- a/joy-infrared/Cargo.toml
+++ b/joy-infrared/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "joy-infrared"
+license = "MIT"
 version = "0.1.0"
 authors = ["yamakaky"]
 edition = "2018"

--- a/joy-music/Cargo.toml
+++ b/joy-music/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "joy-music"
+license = "MIT"
 version = "0.1.0"
 authors = ["Mikaël Fourrier <mikael.fourrier@pm.me>"]
 edition = "2018"

--- a/joytk/Cargo.toml
+++ b/joytk/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "joytk"
+license = "MIT"
 version = "0.1.0"
 authors = ["Mikaël Fourrier <mikael.fourrier@protonmail.com>"]
 edition = "2018"

--- a/wireshark-joycon/Cargo.toml
+++ b/wireshark-joycon/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "wireshark-joycon"
+license = "MIT"
 version = "0.1.0"
 authors = ["Yamakaky <yamakaky@yamaworld.fr>"]
 edition = "2018"


### PR DESCRIPTION
This change makes it easier for software to determine the licenses of
the packages. Doing so doesn’t really have any immediate effects, but
license fields are required for creates to be published to creates.io:
<https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields>