### PR TITLE
Create `scan_for_joycons()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1033,6 +1033,7 @@ dependencies = [
  "hidapi",
  "image",
  "joycon-sys",
+ "thiserror",
  "tracing",
 ]
 
@@ -1040,6 +1041,7 @@ dependencies = [
 name = "joycon-sys"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "bitfield",
  "cgmath",
  "num",

--- a/crates/joycon-sys/Cargo.toml
+++ b/crates/joycon-sys/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
 bitfield = { version = "0.13", optional = false, default-features = false }
 num = { version = "0.4", optional = false, default-features = false }
 num-traits = { version = "0.2", optional = false, default-features = false }

--- a/crates/joycon-sys/src/input/report.rs
+++ b/crates/joycon-sys/src/input/report.rs
@@ -256,8 +256,8 @@ impl fmt::Display for WhichController {
             f,
             "{}",
             match *self {
-                WhichController::LeftJoyCon => "JoyCon (L)",
-                WhichController::RightJoyCon => "JoyCon (R)",
+                WhichController::LeftJoyCon => "Joy-Con (L)",
+                WhichController::RightJoyCon => "Joy-Con (R)",
                 WhichController::ProController => "Pro Controller",
             }
         )

--- a/crates/joycon-sys/src/input/report.rs
+++ b/crates/joycon-sys/src/input/report.rs
@@ -3,6 +3,7 @@
 //! <https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/bluetooth_hid_notes.md#input-reports>
 
 use crate::{accessory::AccessoryResponse, common::*, imu, input::*, mcu::*, raw_enum, spi::*};
+use anyhow::{anyhow, Result};
 use std::{fmt, mem::size_of_val};
 
 raw_enum! {
@@ -248,6 +249,20 @@ pub enum WhichController {
     LeftJoyCon = 1,
     RightJoyCon = 2,
     ProController = 3,
+}
+
+impl WhichController {
+    /// You can use [`hidapi::DeviceInfo::product_id()`](https://docs.rs/hidapi/1.3.4/hidapi/struct.DeviceInfo.html#method.product_id)
+    /// to get an ID to pass to this function.
+    pub fn from_product_id(id: u16) -> Result<Self> {
+        match id {
+            JOYCON_L_BT => Ok(WhichController::LeftJoyCon),
+            JOYCON_R_BT => Ok(WhichController::RightJoyCon),
+            PRO_CONTROLLER => Ok(WhichController::ProController),
+            JOYCON_CHARGING_GRIP => Err(anyhow!("unsupported charging grip")),
+            _ => Err(anyhow!("unknown controller type")),
+        }
+    }
 }
 
 impl fmt::Display for WhichController {

--- a/crates/joycon/Cargo.toml
+++ b/crates/joycon/Cargo.toml
@@ -17,3 +17,4 @@ hid-gamepad-sys = { path = "../hid-gamepad-sys/" }
 enum-map = "0.6"
 tracing = "0.1"
 hex = "0.4"
+thiserror = "1.0.30"

--- a/crates/joycon/src/hid.rs
+++ b/crates/joycon/src/hid.rs
@@ -42,13 +42,7 @@ pub struct JoyCon {
 impl JoyCon {
     #[instrument(level = "info", skip(device), err)]
     pub fn new(device: hidapi::HidDevice, info: hidapi::DeviceInfo) -> Result<JoyCon> {
-        let device_type = match info.product_id() {
-            JOYCON_L_BT => WhichController::LeftJoyCon,
-            JOYCON_R_BT => WhichController::RightJoyCon,
-            PRO_CONTROLLER => WhichController::ProController,
-            JOYCON_CHARGING_GRIP => panic!("unsupported charging grip"),
-            _ => panic!("unknown controller type"),
-        };
+        let device_type = WhichController::from_product_id(info.product_id())?;
         let mut joycon = JoyCon {
             device,
             info,

--- a/crates/joycon/src/lib.rs
+++ b/crates/joycon/src/lib.rs
@@ -2,6 +2,7 @@ mod calibration;
 mod hid;
 mod image;
 mod imu_handler;
+mod scan;
 
 pub use crate::image::*;
 use anyhow::Result;
@@ -12,6 +13,7 @@ use hid_gamepad_sys::{GamepadDevice, GamepadDriver, JoyKey, Motion};
 use hidapi::HidApi;
 pub use imu_handler::IMU;
 pub use joycon_sys;
+pub use scan::*;
 
 pub use hidapi;
 use joycon_sys::{imu::IMU_SAMPLES_PER_SECOND, NINTENDO_VENDOR_ID};

--- a/crates/joycon/src/scan.rs
+++ b/crates/joycon/src/scan.rs
@@ -1,0 +1,83 @@
+use crate::JoyCon;
+use anyhow;
+use hidapi::{DeviceInfo, HidApi, HidError};
+use joycon_sys::{
+    input::WhichController, JOYCON_L_BT, JOYCON_R_BT, NINTENDO_VENDOR_ID, PRO_CONTROLLER,
+};
+use thiserror::Error;
+
+/// Helper for creating [`JoyCon`]s.
+///
+/// The main purpose of this struct is to be returned by [`scan_for_joycons`].
+pub struct DetectedJoyConInfo<'a> {
+    api: &'a HidApi,
+    device_info: &'a DeviceInfo,
+}
+
+/// Helper for [`DetectedJoyConInfo::connect`].
+#[derive(Error, Debug)]
+pub enum ConnectionError {
+    #[error("failed to connect to the device")]
+    Hid(HidError),
+    #[error("failed to create a new JoyCon")]
+    JoyCon(anyhow::Error),
+}
+
+impl DetectedJoyConInfo<'_> {
+    pub fn device_type(&self) -> anyhow::Result<WhichController> {
+        WhichController::from_product_id(self.device_info.product_id())
+    }
+
+    pub fn connect(&self) -> Result<JoyCon, ConnectionError> {
+        match self.device_info.open_device(self.api) {
+            Ok(hid_device) => match JoyCon::new(hid_device, self.device_info.clone()) {
+                Ok(joycon) => Ok(joycon),
+                Err(anyhow_error) => Err(ConnectionError::JoyCon(anyhow_error)),
+            },
+            Err(hid_error) => Err(ConnectionError::Hid(hid_error)),
+        }
+    }
+}
+
+/// An easy way to create [`JoyCon`]s.
+///
+/// Use this function to find all of the Joy-Cons (or Pro Controllers) connected
+/// to the system. you can then connect to them with
+/// [`DetectedJoyConInfo::connect()`].
+///
+/// ```
+/// use joycon::{hidapi::HidApi, joycon_sys::input::WhichController, scan_for_joycons};
+///
+/// fn main() {
+///     let api = HidApi::new().expect("Failed to create new HipApi.");
+///     for joy_con_info in scan_for_joycons(&api) {
+///         let device_type = joy_con_info
+///             .device_type()
+///             .expect("scan_for_joycons returned info for something that isn’t a Joy-Con or a Pro Controller. This should never happen.");
+///
+///         if device_type == WhichController::RightJoyCon {
+///             match joy_con_info.connect() {
+///                 Ok(joy_con) => {
+///                     println!("Successfully connected.");
+///                     assert!(joy_con.supports_ir());
+///                 }
+///                 Err(_) => println!("Failed to connect."),
+///             }
+///         }
+///     }
+/// }
+/// ```
+pub fn scan_for_joycons(api: &HidApi) -> Vec<DetectedJoyConInfo> {
+    let mut return_value: Vec<DetectedJoyConInfo> = Vec::new();
+    for device in api.device_list() {
+        if device.vendor_id() == NINTENDO_VENDOR_ID
+            && [JOYCON_L_BT, JOYCON_R_BT, PRO_CONTROLLER].contains(&device.product_id())
+        {
+            return_value.push(DetectedJoyConInfo {
+                api: api,
+                device_info: device,
+            });
+        }
+    }
+    return_value
+}


### PR DESCRIPTION
The goal of this PR is to make it easier to create new [`JoyCon`](https://yamakaky.github.io/joy/joycon/struct.JoyCon.html)s.

Here’s some things that I was unsure about:

- I put what I created into a new `scan.rs` file. I’m not very familiar with how this project is organized, so I don’t really know if that’s a good place to put it.
- I wanted `DetectedJoyConInfo::connect` to return a `Result`, but I had two error types instead of one. I created `ConnectionError` to solve this problem, but I’m not sure if that’s the best solution.